### PR TITLE
feat: Add support for extra start parameters

### DIFF
--- a/iw4xentry.sh
+++ b/iw4xentry.sh
@@ -83,6 +83,10 @@ fi
 
 CMD_ARGS+=(+map_rotate)
 
+if [[ -n "${IW4X_EXTRA_ARGS}" ]]; then
+    CMD_ARGS+=(${IW4X_EXTRA_ARGS})
+fi
+
 # --- Step 5: Launch the iw4x Server ---
 echo "Starting ${IW4X_GAME} Server: ${IW4X_SERVER_NAME}"
 echo "EXECUTING: wine iw4x.exe ${CMD_ARGS[@]}"

--- a/plutoentry.sh
+++ b/plutoentry.sh
@@ -138,6 +138,10 @@ else
     CMD_ARGS+=(+map_rotate)
 fi
 
+if [[ -n "${PLUTO_EXTRA_ARGS}" ]]; then
+    CMD_ARGS+=(${PLUTO_EXTRA_ARGS})
+fi
+
 # --- Step 5: Launch the Plutonium Server ---
 echo "Starting Plutonium ${PLUTO_GAME} Server: ${PLUTO_SERVER_NAME}"
 echo "EXECUTING: wine bin/plutonium-bootstrapper-win32.exe ${CMD_ARGS[@]}"


### PR DESCRIPTION
This change introduces two new environment variables, `PLUTO_EXTRA_ARGS` and `IW4X_EXTRA_ARGS`, which allow users to provide additional command-line arguments to the Plutonium and IW4x game servers, respectively.

This provides greater flexibility for per-user customization without needing to modify the base Docker image.