### PR TITLE
Add 7 Days to Die server support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ amd64 is required. **arm64 is best-effort** (`optional: true` + `continue-on-err
 
 **cod4x is amd64-only by nature**, not by build failure: upstream's native Linux server is a 32-bit x86 ELF, which cannot execute on arm64 at all. `cod4xentry.sh` refuses with an explanation.
 
+**7dtd is amd64-only**: SteamCMD installs the official x86_64 native Linux server. The arm64 image includes the dispatcher script so it can refuse clearly, but does not include SteamCMD or Linux-user-space x86 emulation.
+
 **Degradation.** `Dockerfile.arm64` lets the launcher build fail, writing the `.unavailable` marker in its place. Stage 3 copies `/out/` as a **directory**, not a file — a file `COPY` of a missing path aborts the build, which is the coupling being avoided; the marker also keeps the directory non-empty. `iw4xentry.sh` tests `-x` on the binary and `hold_indefinitely`s if absent. That is a capability check, not an arch check, so iw4x starts working again as soon as an image ships a binary, with no code change.
 
 **`IW4X_LAUNCHER_REF` is load-bearing — do not remove it.** Both Dockerfiles fetch the launcher inside a `RUN`, so the layer cache key never changes on its own and upstream changes stay invisible until eviction. CI resolves the upstream ref (release tag for amd64, commit SHA for arm64) and passes it purely to key the cache. This matters most on arm64, where the `|| { … }` fallback makes the step exit 0 on failure, so a failed build caches as a success and would keep shipping the marker indefinitely.
@@ -125,11 +127,13 @@ Everything runs as the `plutainer` user from `/home/plutainer/.plutainer`. All e
 
    Without `PLUTAINER_COD4X_AUTH_TOKEN` the launch passes `sv_authorizemode -1`; the server runs and is fully playable, just unlisted on the master.
 
-6. **`game-config.sh`** — Shared shell library sourced by all other scripts. Key helpers:
+6. **`7dtdentry.sh`** — Native Linux 7 Days to Die entrypoint. SteamCMD anonymously installs app 294420 into `app/runtime/7dtd/`; persistent worlds and logs live in `app/runtime/7dtd-data/`. The current depot's XML template is copied once to `app/configs/serverconfig.xml`, and `PLUTAINER_PORT` updates only its `ServerPort` value. No gamefiles mount or Wine is involved.
+
+7. **`game-config.sh`** — Shared shell library sourced by all other scripts. Key helpers:
    - Volume path constants: `PLUTAINER_APP_DIR`, `PLUTAINER_CONFIGS_DIR`, `PLUTAINER_RUNTIME_DIR`, `PLUTAINER_GAMEFILES_DIR`, `PLUTAINER_PLUTONIUM_DIR`, `PLUTAINER_SOURCE_DIR`.
    - `hold_indefinitely <msg>`: print the error, then `exec sleep infinity` so the container stays `Up` instead of looping through restarts. Used for any startup validation failure.
    - `launch_game <cmd>...`: wraps the game invocation; on exit, sleeps 30s before letting the script exit, so docker's restart policy throttles to ~1 restart per 30s.
-   - `derive_family <game-tag>`: returns `plutonium`/`iw4x`/`alterware`.
+   - `derive_family <game-tag>`: returns `plutonium`/`iw4x`/`alterware`/`cod4x`/`7dtd`.
    - `detect_game_type`: validates `PLUTAINER_GAME` (no shim — only PLUTAINER_* accepted), sets `GAME_TYPE`/`GAME_NAME`/`BASE_GAME`/`CONFIG_FILE`/`CUSTOM_PORT`/`HEALTHCHECK_FLAG`.
    - `resolve_default_port`, `resolve_engine_config_dir`, `resolve_mod_config_dir`.
    - `resolve_config_layout`: sets `CONFIG_SOT_DIR` and `ALT_CONFIG_DIR` based on `PLUTAINER_USE_RAW_CONFIGS`. Default: SOT = `configs/`, ALT = engine dir. With raw mode on: swapped.
@@ -192,7 +196,7 @@ Everything runs as the `plutainer` user from `/home/plutainer/.plutainer`. All e
 
 For Plutonium, `BASE_GAME` is derived by stripping the last two chars from `PLUTAINER_GAME` (e.g., `t6zm` → `t6`). This drives:
 
-- **Default ports**: iw4x→28960, iw5→27016, t4/t5→28960, t6→4976, t7x→27017.
+- **Default ports**: iw4x→28960, iw5→27016, t4/t5→28960, t6→4976, t7x→27017, 7dtd→26900.
 - **Engine config dirs** (where the game reads `+exec`'d cfg files): t4 → `runtime/gamefiles/main/`, iw5 → `runtime/gamefiles/admin/`, iw4x → `runtime/gamefiles/userraw/`, t7x → `runtime/gamefiles/zone/`, others → `runtime/plutonium/storage/<base_game>/`.
 - **Command args**: iw5 uses `+set sv_config` and `+start_map_rotate`; others use `+exec` and `+map_rotate`. The map-rotate arg is opt-out family-wide via `PLUTAINER_MAP_ROTATE=false` (Plutonium + IW4x; T7x never had one).
 - **Game-file symlinks** differ per base game (see `plutoentry.sh` case statement).
@@ -210,4 +214,4 @@ Two distinct failure modes:
 - **Configuration errors** (validation failures, missing env vars, missing config file, v1 volume, unknown game): `hold_indefinitely` → `exec sleep infinity`. Container stays `Up`; healthcheck eventually marks it unhealthy. No restart loop. User fixes and runs `docker restart <name>`.
 - **Runtime crashes** (wine exits): `launch_game` wrapper catches the exit, sleeps 30s, then exits with the original return code. Docker's restart policy fires after that, giving ~1 restart per 30s instead of immediate churn.
 
-`STOPSIGNAL` is `SIGKILL`, so neither path interferes with `docker stop` — that's instant by design.
+`STOPSIGNAL` is `SIGTERM`. `launch_game` traps it and preserves immediate-stop behaviour for the CoD families. The 7DTD entrypoint supplies `graceful_shutdown_game`, which forwards SIGTERM to the native server and lets its `ServerShutdown` path save before exiting; Docker's configured stop timeout remains the hard upper bound.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,15 @@ WORKDIR /home/plutainer/.plutainer
 # missing display driver and still initialises the prefix.
 RUN wineboot -u && wineserver -w
 
+# SteamCMD installs and updates the native 7 Days to Die dedicated server at
+# runtime. It is a 32-bit bootstrapper; the multilib libraries above satisfy
+# it, while the game server it installs is x86_64.
+RUN mkdir -p steamcmd && \
+    wget -qO steamcmd/steamcmd_linux.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz && \
+    tar -xzf steamcmd/steamcmd_linux.tar.gz -C steamcmd && \
+    rm steamcmd/steamcmd_linux.tar.gz && \
+    steamcmd/steamcmd.sh +quit
+
 RUN wget https://github.com/mxve/plutonium-updater.rs/releases/latest/download/plutonium-updater-x86_64-unknown-linux-gnu.tar.gz -O plutonium-updater.tar.gz && \
     tar -xzvf plutonium-updater.tar.gz && \
     rm plutonium-updater.tar.gz
@@ -95,13 +104,13 @@ COPY --chown=plutainer:plutainer seed-configs/ seed-configs/
 
 COPY --chown=plutainer:plutainer scripts/ .
 RUN chmod +x entrypoint.sh healthcheck.sh plutoentry.sh iw4xentry.sh alterentry.sh \
-              cod4xentry.sh log-watcher.sh rcon-cli game-config.sh migrate-v1-to-v2.sh
+              cod4xentry.sh 7dtdentry.sh log-watcher.sh rcon-cli game-config.sh migrate-v1-to-v2.sh
 
 USER root
 RUN ln -s /home/plutainer/.plutainer/rcon-cli /usr/local/bin/rcon-cli
 USER plutainer
 
-STOPSIGNAL SIGKILL
+STOPSIGNAL SIGTERM
 
 HEALTHCHECK --interval=1m --timeout=10s --start-period=5m --retries=3 \
   CMD ./healthcheck.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -154,13 +154,13 @@ COPY --chown=plutainer:plutainer seed-configs/ seed-configs/
 
 COPY --chown=plutainer:plutainer scripts/ .
 RUN chmod +x entrypoint.sh healthcheck.sh plutoentry.sh iw4xentry.sh alterentry.sh \
-              cod4xentry.sh log-watcher.sh rcon-cli game-config.sh migrate-v1-to-v2.sh
+              cod4xentry.sh 7dtdentry.sh log-watcher.sh rcon-cli game-config.sh migrate-v1-to-v2.sh
 
 USER root
 RUN ln -s /home/plutainer/.plutainer/rcon-cli /usr/local/bin/rcon-cli
 USER plutainer
 
-STOPSIGNAL SIGKILL
+STOPSIGNAL SIGTERM
 
 HEALTHCHECK --interval=1m --timeout=10s --start-period=5m --retries=3 \
   CMD ./healthcheck.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plutainer
 
-Run a Call of Duty dedicated server in Docker. One image, seven games, configured with environment variables.
+Run supported dedicated game servers in Docker. One image, eight games, configured with environment variables.
 
 ```yaml
 services:
@@ -32,8 +32,9 @@ services:
 | Modern Warfare 2 (IW4x) | `iw4x` | No key. amd64 only |
 | Black Ops III (T7x) | `t7x` | Alterware. No key |
 | Modern Warfare (CoD4x) | `cod4x` | Multiplayer only, amd64 only. Needs a [masterserver token](docs/games.md#cod4x-modern-warfare) to appear in the server browser |
+| 7 Days to Die | `7dtd` | Native Linux server, amd64 only. Installed automatically with SteamCMD; no gamefiles mount |
 
-Image: `ghcr.io/ayymoss/plutainer:latest` — multi-arch (amd64 + arm64), with [two exceptions](docs/games.md#architecture-support).
+Image: `ghcr.io/ayymoss/plutainer:latest` — multi-arch (amd64 + arm64), with [documented architecture exceptions](docs/games.md#architecture-support).
 
 ## Documentation
 
@@ -53,7 +54,7 @@ Image: `ghcr.io/ayymoss/plutainer:latest` — multi-arch (amd64 + arm64), with [
 ## What Plutainer does for you
 
 - **Writes a working config on first start.** Community defaults are seeded into `app/configs/`, and never overwrite files you've edited.
-- **Fetches the server binaries.** Plutonium, IW4x and T7x updaters run at startup; CoD4x ships in the image. You supply only the base game files.
+- **Fetches the server binaries.** Plutonium, IW4x and T7x updaters run at startup; CoD4x ships in the image; 7DTD is installed with SteamCMD. You supply base game files only for games that need them.
 - **Puts every config in one folder.** Edit `app/configs/whatever.cfg`; Plutainer symlinks it to wherever the engine expects it.
 - **Keeps logs findable.** `app/logs/` holds stable symlinks to the active log files, wherever the game moved them.
 - **Fails loudly, not endlessly.** A misconfiguration holds the container in `Up` with a readable error instead of a restart loop.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,8 +6,8 @@ Every setting is an environment variable. Only two are required.
 
 | Variable | Description |
 | --- | --- |
-| `PLUTAINER_GAME` | Which game — `t4mp`, `t4sp`, `t5mp`, `t5sp`, `t6mp`, `t6zm`, `iw5mp`, `iw4x`, `t7x`, `cod4x` |
-| `PLUTAINER_CONFIG_FILE` | Which config to run, e.g. `dedicated_zm.cfg`. Must exist in `app/configs/` — Plutainer seeds one on first start ([names per game](games.md)) |
+| `PLUTAINER_GAME` | Which game — `t4mp`, `t4sp`, `t5mp`, `t5sp`, `t6mp`, `t6zm`, `iw5mp`, `iw4x`, `t7x`, `cod4x`, `7dtd` |
+| `PLUTAINER_CONFIG_FILE` | Which config to run, e.g. `dedicated_zm.cfg`. Must exist in `app/configs/` — Plutainer seeds one on first start ([names per game](games.md)). Optional for 7DTD, where it defaults to `serverconfig.xml` |
 
 Plutonium games (`t4*`, `t5*`, `t6*`, `iw5mp`) also require `PLUTO_SERVER_KEY`.
 
@@ -17,7 +17,7 @@ Plutonium games (`t4*`, `t5*`, `t6*`, `iw5mp`) also require `PLUTO_SERVER_KEY`.
 | --- | --- | --- |
 | `PLUTAINER_PORT` | Network port | [per game](games.md) |
 | `PLUTAINER_RCON_PASSWORD` | Sets `rcon_password` in your config at startup. Opt-in — unset leaves your config untouched | unset |
-| `PLUTAINER_SERVER_NAME` | Name shown in Plutainer's own startup logs (not the in-game hostname — that's `sv_hostname` in your cfg) | per family |
+| `PLUTAINER_SERVER_NAME` | Name shown in Plutainer's startup logs. For 7DTD this also sets XML `ServerName`; CoD engines still use `sv_hostname` in their cfg | per family |
 | `PLUTAINER_MOD` | Mod folder name. On T7x, a Steam Workshop ID instead | unset |
 | `PLUTAINER_MAP_ROTATE` | `false` drops the automatic `+map_rotate` (`+start_map_rotate` on IW5), leaving map choice to your cfg or playlist. N/A on T7x | `true` |
 | `PLUTAINER_EXTRA_ARGS` | Extra arguments appended to the launch command | unset |
@@ -46,6 +46,7 @@ These only apply to one engine family.
 | `PLUTAINER_DEDICATED` | `dedicated` value: `2` public, `1` LAN (default `2`) | CoD4x |
 | `PLUTAINER_RCON_WHITELIST` | Extra addresses allowed to send RCON, comma separated. See [IW4MAdmin](iw4madmin.md) | T5, T6 |
 | `PLUTAINER_RCON_WHITELIST_GATEWAY` | `false` stops auto-whitelisting the Docker gateway (default `true`) | T5, T6 |
+| `PLUTAINER_7DTD_BETA` | Optional Steam beta branch, for example `latest_experimental` | 7 Days to Die |
 
 ## Ports
 
@@ -55,6 +56,7 @@ These only apply to one engine family.
 | t6 | 4976 |
 | iw5 | 27016 |
 | t7x | 27017 |
+| 7dtd | 26900 |
 
 Publish as **UDP**. IW4x additionally wants TCP published if you host mods, for modlist metadata:
 
@@ -62,6 +64,14 @@ Publish as **UDP**. IW4x additionally wants TCP published if you host mods, for 
 ports:
   - "28960:28960/udp"
   - "28960:28960/tcp"   # IW4x mod hosting only
+```
+
+7DTD uses TCP and UDP on its base port plus the next three UDP ports. With the default:
+
+```yaml
+ports:
+  - "26900:26900/tcp"
+  - "26900-26903:26900-26903/udp"
 ```
 
 ## Legacy variables

--- a/docs/games.md
+++ b/docs/games.md
@@ -13,6 +13,7 @@ What each game needs from you, and what Plutainer supplies. Find your game, chec
 | Modern Warfare 2 | `iw4x` | no | 28960 | `server.cfg`, `serverlan.cfg`, `partyserver.cfg`, `partyserverlan.cfg` |
 | Black Ops III | `t7x` | no | 27017 | `server.cfg`, `server_zm.cfg`, `server_cp.cfg` |
 | Modern Warfare | `cod4x` | token, to be listed | 28960 | `server.cfg` |
+| 7 Days to Die | `7dtd` | no | 26900 | `serverconfig.xml` from the Steam depot |
 
 `PLUTAINER_CONFIG_FILE` must name one of the seeded files, or a config you place in `app/configs/` yourself. Get it wrong and the container refuses to start with a hint listing what it found — including case-only mismatches like `Server.cfg` vs `server.cfg`.
 
@@ -21,6 +22,8 @@ The `sp` tags are how Plutonium runs zombies/co-op: **T4 zombies is `t4sp`** wit
 ## What goes in the gamefiles mount
 
 Mounted read-only at `/home/plutainer/gamefiles`. One copy can be shared by any number of servers.
+
+**7 Days to Die is the exception:** do not mount game files. Plutainer installs the official dedicated server anonymously through SteamCMD into `app/runtime/7dtd/` and keeps world data in `app/runtime/7dtd-data/`.
 
 ### Plutonium (T4, T5, T6, IW5)
 
@@ -47,6 +50,20 @@ BO3 server files: `BlackOps3_UnrankedDedicatedServer.exe`, `zone/`, `machinecfg`
 Plutainer ships the server binary and the two assets a stock install lacks — `cod4x_patchv2.ff` and `jcod4x_00.iwd` — so nothing is downloaded at runtime.
 
 ## Per-game notes
+
+### 7 Days to Die
+
+Use `PLUTAINER_GAME=7dtd`. On first start SteamCMD downloads dedicated-server app `294420`; later starts update it unless `PLUTAINER_AUTO_UPDATE=false`. The current depot's `serverconfig.xml` is copied to `app/configs/serverconfig.xml` only when that file does not already exist, so your edits persist.
+
+Allow roughly 15 GB of persistent storage for the Linux depot, plus additional space for generated worlds, saves, and mods.
+
+`PLUTAINER_PORT` updates the XML `ServerPort` property at startup. Publish that port as TCP and UDP, plus the following three UDP ports. For the default this is TCP `26900` and UDP `26900-26903`.
+
+No gamefiles mount, Steam account, or game key is required. The server is amd64-only. Plutainer's Quake RCON client does not apply to 7DTD; use the game's own telnet/web administration options configured in `serverconfig.xml`.
+
+On container stop, Plutainer forwards `SIGTERM` to the native Linux server and waits while its `ServerShutdown` path saves the world and exits. Set `stop_grace_period: 2m` as shown in the Compose example; Docker's stop timeout remains the hard limit if the game hangs.
+
+`PLUTAINER_USE_RAW_CONFIGS` and `PLUTAINER_MOD` do not apply. Put server mods in `app/runtime/7dtd/Mods/` so SteamCMD leaves them alongside the persistent installation.
 
 ### T5 (Black Ops)
 
@@ -101,6 +118,7 @@ Upstream ships `sv_maprotation` commented out, which would leave `+map_rotate` w
 
 - **IW4x does not work on arm64.** Upstream publishes `x86_64` binaries only, so the arm64 image builds the launcher from source, and that build is currently broken ([iw4x/launcher#76](https://github.com/iw4x/launcher/issues/76)). It refuses to start and says why. It will work again automatically once upstream builds.
 - **CoD4x is amd64-only, permanently.** Its server is a 32-bit x86 Linux binary, which cannot execute on arm64 at all.
+- **7 Days to Die is amd64-only.** SteamCMD and the official native Linux dedicated server are x86 binaries; the arm64 image deliberately refuses with an explanation.
 
 Plutonium and T7x work on both. If an arm64 build fails outright, `:latest` publishes amd64-only rather than being held back — check with `docker manifest inspect ghcr.io/ayymoss/plutainer:latest` before upgrading an arm64 host.
 

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -2,11 +2,13 @@
 
 ## What "healthy" means
 
-Plutainer asks the server for its status and requires it to **name a loaded map**. A container is healthy only when the game is genuinely serving — not merely when the process is alive.
+For Call of Duty engines, Plutainer asks the server for its status and requires it to **name a loaded map**. For 7 Days to Die, it requires the dedicated process and a successful TCP connection to the configured game port.
 
 1. Work out the game and port.
 2. Send an unauthenticated `getstatus` to `127.0.0.1`, falling back to `getinfo`.
 3. Require a map name in the reply.
+
+The 7DTD branch instead checks `7DaysToDieServer.x86_64` and connects to `127.0.0.1:<game port>`; it does not speak the Quake status protocol.
 
 ```
 [OK] Health check passed: Server is responsive on port 4976 (map: zm_buried (via getstatus)).
@@ -20,7 +22,7 @@ Disable with `PLUTAINER_HEALTHCHECK=false`.
 
 ### Start period
 
-The healthcheck allows **five minutes** before failures count, because a first start downloads a lot (IW4x 1–2 GB, Plutonium ~500 MB). During that window `docker ps` shows `starting`.
+The healthcheck allows **five minutes** before failures count, because a first start downloads a lot (including the full 7DTD dedicated server through SteamCMD). During that window `docker ps` shows `starting`.
 
 ## Restart behaviour
 
@@ -32,7 +34,7 @@ No restart loop, no log spam burying the error. Fix it and `docker restart <cont
 
 **Runtime crashes** — the game exits on its own. Plutainer waits **30 seconds**, then exits with the game's code, letting your `restart:` policy take over. That throttles a crash loop to roughly one restart per 30s instead of hammering.
 
-`STOPSIGNAL` is `SIGKILL`, so `docker stop` is immediate either way.
+Docker sends `SIGTERM` to Plutainer's launch wrapper. Call of Duty families retain their immediate-stop behaviour. For 7DTD, the wrapper forwards the signal to the native server and waits for its `ServerShutdown` save path to finish; its Compose example allows a two-minute grace period. Docker still force-kills the container if that timeout expires.
 
 ## Auto-restarting unhealthy servers
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,11 +7,11 @@ Getting one server running, start to finish. Budget ten minutes, most of it wait
 You need three things:
 
 1. **Docker and Docker Compose** on a Linux host.
-2. **The base game files**, which you must own. Plutainer ships no game content. What exactly each game needs is in [Games](games.md).
+2. **The base game files**, which you must own for the Call of Duty engines. 7DTD is installed automatically with SteamCMD and needs no gamefiles mount. What exactly each game needs is in [Games](games.md).
 3. **A server key or token**, depending on the game:
    - **T4, T5, T6, IW5** need a Plutonium server key, free from <https://platform.plutonium.pw/serverkeys>. The server will not start without one.
    - **CoD4x** needs a masterserver token from <http://cod4master.cod4x.ovh> to be listed in the server browser. It runs without one, but nobody will find it.
-   - **IW4x and T7x** need nothing.
+   - **IW4x, T7x, and 7DTD** need no key or token.
 
 ## 1. Put the game files somewhere
 
@@ -22,6 +22,8 @@ Anywhere on the host. They're mounted read-only, so they can be shared by as man
   T6ServerFiles/
   IW4xServerFiles/
 ```
+
+Skip this step for 7 Days to Die.
 
 ## 2. Write a compose file
 
@@ -51,7 +53,7 @@ Four settings matter:
 | --- | --- |
 | `PLUTAINER_GAME` | Which game. [Full list](games.md) |
 | `PLUTAINER_CONFIG_FILE` | Which config to run. **Must be one Plutainer seeds** unless you supply your own — [names per game](games.md) |
-| the gamefiles mount | Your base game files, read-only |
+| the gamefiles mount | Your base game files, read-only (not used by 7DTD) |
 | the app mount | Where server data, configs and logs live |
 
 Put the key in a `.env` file next to your compose file so it stays out of the compose:
@@ -67,7 +69,7 @@ docker compose up -d
 docker compose logs -f
 ```
 
-**First start takes a while.** Plutonium downloads ~500 MB, IW4x 1–2 GB. CoD4x is ready in under a minute since everything ships in the image. The healthcheck allows five minutes before it starts judging.
+**First start takes a while.** Plutonium downloads ~500 MB, IW4x 1–2 GB, and 7DTD downloads its full dedicated-server depot. CoD4x is ready in under a minute since everything ships in the image. The healthcheck allows five minutes before it starts judging.
 
 ## 4. Check it worked
 
@@ -75,7 +77,7 @@ docker compose logs -f
 docker ps
 ```
 
-`healthy` means the server answered a status query and reported a loaded map — it's genuinely up, not just running. If it says `unhealthy` or never leaves `starting`, go to [Troubleshooting](troubleshooting.md).
+`healthy` means a Call of Duty server answered a status query and reported a loaded map, or that 7DTD's process is running and its game port accepts TCP connections. If it says `unhealthy` or never leaves `starting`, go to [Troubleshooting](troubleshooting.md).
 
 ## 5. Edit your config
 

--- a/docs/rcon.md
+++ b/docs/rcon.md
@@ -1,5 +1,7 @@
 # RCON
 
+This page applies to the Call of Duty engines. 7 Days to Die uses its own telnet/web administration configured in `serverconfig.xml`; Plutainer's `rcon-cli` does not support it.
+
 Sending commands to a running server.
 
 ## Set a password first

--- a/docs/volumes-and-configs.md
+++ b/docs/volumes-and-configs.md
@@ -11,17 +11,21 @@ Where everything lives, and why your configs are in one folder instead of scatte
 
 The gamefiles mount is read-only and shareable — point ten servers at the same copy. Anything an updater downloads goes into `app/` instead, so don't stage binaries in the gamefiles mount.
 
+7 Days to Die does not use `/home/plutainer/gamefiles`; SteamCMD installs it under the app volume instead.
+
 ## What appears in `app/`
 
 Created on first start:
 
 ```
 app/
-  configs/            ← your *.cfg files. This is the one you care about
+  configs/            ← your *.cfg files (or serverconfig.xml for 7DTD)
   logs/               ← stable symlinks to the active *.log files
   runtime/
     gamefiles/        ← symlinks into your read-only mount + writable game state
     plutonium/        ← Plutonium binaries and storage
+    7dtd/             ← SteamCMD-managed dedicated server (7DTD only)
+    7dtd-data/        ← worlds, saves, and server log (7DTD only)
   .plutainer-version  ← layout marker
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,9 @@ Copy the one that matches what you're doing, adjust the paths, `docker compose u
 
 ## The three things you must change
 
-1. **The gamefiles path** — `/opt/game-files/…` in every example. Point it at your own copy.
-2. **`PLUTAINER_CONFIG_FILE`** — must name a config Plutainer seeds for that game ([list](../docs/games.md#at-a-glance)).
-3. **Ports** — one server per port. Publish UDP.
+1. **The gamefiles path** — `/opt/game-files/…` in most examples. Point it at your own copy. 7DTD needs no gamefiles mount.
+2. **`PLUTAINER_CONFIG_FILE`** — must name a config Plutainer seeds for that game ([list](../docs/games.md#at-a-glance)); 7DTD defaults to `serverconfig.xml`.
+3. **Ports** — one server per port. Most games publish UDP; follow the 7DTD example's TCP/UDP range.
 
 ## Secrets
 

--- a/examples/per-game.yml
+++ b/examples/per-game.yml
@@ -174,3 +174,24 @@ services:
       # but never registers with the master, so nobody finds it.
       # 32-character token from http://cod4master.cod4x.ovh
       # PLUTAINER_COD4X_AUTH_TOKEN: ${COD4X_TOKEN}
+
+  # ----------------------------------------------------------- 7 Days to Die
+  # Native Linux dedicated server, installed automatically by SteamCMD.
+  # amd64 only. No gamefiles mount, Steam login, or key required.
+  7dtd-1:
+    image: ghcr.io/ayymoss/plutainer:latest
+    container_name: 7dtd-1
+    restart: unless-stopped
+    # Allow the native shutdown handler time to save and close the world.
+    stop_grace_period: 2m
+    ports:
+      - "26900:26900/tcp"
+      - "26900-26903:26900-26903/udp"
+    volumes:
+      - ./7dtd-1:/home/plutainer/app
+    environment:
+      PLUTAINER_GAME: 7dtd
+      PLUTAINER_CONFIG_FILE: serverconfig.xml
+      PLUTAINER_PORT: "26900"
+      # Optional Steam branch:
+      # PLUTAINER_7DTD_BETA: latest_experimental

--- a/scripts/7dtdentry.sh
+++ b/scripts/7dtdentry.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+#
+# 7 Days to Die dedicated server entrypoint.
+# The official Linux server is installed into the persistent app volume with
+# SteamCMD; no separately mounted game files are required.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/game-config.sh"
+
+detect_game_type || hold_indefinitely "Could not detect the configured game."
+
+if [[ "$(uname -m)" != "x86_64" ]]; then
+  hold_indefinitely "7 Days to Die is amd64-only: its official Linux dedicated server is an x86_64 binary."
+fi
+
+STEAMCMD="/home/plutainer/.plutainer/steamcmd/steamcmd.sh"
+SERVER_DIR="$PLUTAINER_RUNTIME_DIR/7dtd"
+DATA_DIR="$PLUTAINER_RUNTIME_DIR/7dtd-data"
+SERVER_BINARY="$SERVER_DIR/7DaysToDieServer.x86_64"
+
+mkdir -p "$SERVER_DIR" "$DATA_DIR" "$PLUTAINER_CONFIGS_DIR" "$PLUTAINER_APP_DIR/logs"
+
+if [[ ! -x "$STEAMCMD" ]]; then
+  hold_indefinitely "SteamCMD is unavailable in this image. 7 Days to Die requires the linux/amd64 image."
+fi
+
+if [[ "${PLUTAINER_AUTO_UPDATE:-true}" != "false" ]]; then
+  echo "[INFO] Installing/updating 7 Days to Die Dedicated Server (Steam app 294420)..."
+  steam_args=(
+    +force_install_dir "$SERVER_DIR"
+    +login anonymous
+    +app_update 294420
+  )
+  if [[ -n "${PLUTAINER_7DTD_BETA:-}" ]]; then
+    steam_args+=( -beta "$PLUTAINER_7DTD_BETA" )
+  fi
+  steam_args+=( +quit )
+  "$STEAMCMD" "${steam_args[@]}" || hold_indefinitely "SteamCMD could not install/update 7 Days to Die. See the output above."
+elif [[ ! -x "$SERVER_BINARY" ]]; then
+  hold_indefinitely "PLUTAINER_AUTO_UPDATE=false, but no 7 Days to Die server is installed at $SERVER_BINARY."
+else
+  echo "[INFO] Auto-update disabled; using the existing 7 Days to Die installation."
+fi
+
+if [[ ! -x "$SERVER_BINARY" ]]; then
+  hold_indefinitely "SteamCMD completed, but $SERVER_BINARY is missing or not executable."
+fi
+
+# The Steam depot provides the authoritative config template. Copy it only on
+# first run so image/game updates never overwrite the user's settings.
+CONFIG_FILE="${PLUTAINER_CONFIG_FILE:-serverconfig.xml}"
+CONFIG_PATH="$PLUTAINER_CONFIGS_DIR/$CONFIG_FILE"
+if [[ ! -e "$CONFIG_PATH" && "$CONFIG_FILE" == "serverconfig.xml" && "${PLUTAINER_SKIP_SEED:-false}" != "true" && -f "$SERVER_DIR/serverconfig.xml" ]]; then
+  cp "$SERVER_DIR/serverconfig.xml" "$CONFIG_PATH"
+  echo "[INFO] Created $CONFIG_PATH from the current Steam server template."
+fi
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "[ERROR] PLUTAINER_CONFIG_FILE='$CONFIG_FILE' but no such file exists at $CONFIG_PATH." >&2
+  echo "[ERROR] Put an XML server config in $PLUTAINER_CONFIGS_DIR, or use the default serverconfig.xml." >&2
+  hold_indefinitely "7 Days to Die configuration is missing."
+fi
+
+# PLUTAINER_PORT and PLUTAINER_SERVER_NAME live in XML for 7DTD rather than in
+# command-line cvars. Apply them without reserializing the document, preserving
+# the stock template's comments and formatting.
+if [[ -n "${CUSTOM_PORT:-}" || -n "${PLUTAINER_SERVER_NAME:-}" ]]; then
+  set +e
+  CONFIG_TARGET="$CONFIG_PATH" \
+  CONFIG_PORT="${CUSTOM_PORT:-}" \
+  CONFIG_SERVER_NAME="${PLUTAINER_SERVER_NAME:-}" \
+  python3 - <<'PY'
+import os
+import re
+import sys
+from xml.sax.saxutils import escape
+
+path = os.environ["CONFIG_TARGET"]
+port = os.environ["CONFIG_PORT"]
+server_name = os.environ["CONFIG_SERVER_NAME"]
+
+if port:
+    try:
+        port_value = int(port)
+    except ValueError:
+        print(f"[ERROR] PLUTAINER_PORT must be an integer, got {port!r}.", file=sys.stderr)
+        sys.exit(1)
+    if not 1 <= port_value <= 65535:
+        print(f"[ERROR] PLUTAINER_PORT must be between 1 and 65535, got {port_value}.", file=sys.stderr)
+        sys.exit(1)
+
+with open(path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+
+updated = text
+
+def set_property(name, desired):
+    global updated
+    pattern = re.compile(
+        rf'(<property\s+name=["\']{re.escape(name)}["\']\s+value=["\'])'
+        r'[^"\']*'
+        r'(["\'])',
+        re.IGNORECASE,
+    )
+    if not pattern.search(updated):
+        print(f"[ERROR] The XML config has no {name} property.", file=sys.stderr)
+        sys.exit(1)
+    encoded = escape(str(desired), {'"': '&quot;', "'": '&apos;'})
+    updated = pattern.sub(rf"\g<1>{encoded}\g<2>", updated, count=1)
+
+if port:
+    set_property("ServerPort", port_value)
+if server_name:
+    set_property("ServerName", server_name)
+
+if updated != text:
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(updated)
+    applied = []
+    if port:
+        applied.append(f"ServerPort={port_value}")
+    if server_name:
+        applied.append(f"ServerName={server_name!r}")
+    print(f"[INFO] Set {', '.join(applied)} in {os.path.basename(path)}.")
+PY
+  port_config_rc=$?
+  set -e
+  if [[ $port_config_rc -ne 0 ]]; then
+    hold_indefinitely "Could not apply Plutainer settings to the 7 Days to Die XML config."
+  fi
+fi
+
+if [[ "${PLUTAINER_LOG_SYMLINKS:-true}" != "false" ]]; then
+  "$SCRIPT_DIR/log-watcher.sh" &
+fi
+
+LOG_FILE="$DATA_DIR/server-output.log"
+echo "[INFO] Starting ${PLUTAINER_SERVER_NAME:-7 Days to Die} with config $CONFIG_PATH."
+echo "[INFO] Persistent world data: $DATA_DIR"
+
+extra_args=()
+if [[ -n "${PLUTAINER_EXTRA_ARGS:-}" ]]; then
+  # Match the existing entrypoints' compatibility behaviour: this variable is
+  # intentionally shell-tokenised, so users can pass multiple launch flags.
+  read -r -a extra_args <<< "$PLUTAINER_EXTRA_ARGS"
+fi
+
+# Docker sends SIGTERM to the entrypoint. Forward it to the native Linux server,
+# which runs its ServerShutdown path, saves world state, and exits. The shared
+# launch wrapper waits for that exit; Docker's stop timeout is the upper bound.
+graceful_shutdown_game() {
+  local game_pid="$1"
+  echo "[INFO] Forwarding SIGTERM to 7DTD process ${game_pid}."
+  kill -TERM "$game_pid"
+}
+
+cd "$SERVER_DIR"
+export LD_LIBRARY_PATH="$SERVER_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+launch_game "$SERVER_BINARY" \
+  -logfile "$LOG_FILE" \
+  -quit -batchmode -nographics -dedicated \
+  -configfile="$CONFIG_PATH" \
+  -UserDataFolder="$DATA_DIR" \
+  "${extra_args[@]}"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -52,7 +52,7 @@ fi
 
 # --- Detect game type from PLUTAINER_GAME ---
 if ! detect_game_type; then
-  hold_indefinitely "Set PLUTAINER_GAME to one of: t4mp, t4sp, t5mp, t5sp, t6mp, t6zm, iw5mp, iw4x, t7x"
+  hold_indefinitely "Set PLUTAINER_GAME to one of: t4mp, t4sp, t5mp, t5sp, t6mp, t6zm, iw5mp, iw4x, t7x, cod4x, 7dtd"
 fi
 
 # --- Dispatch to game-specific entrypoint ---
@@ -72,5 +72,9 @@ case "$GAME_TYPE" in
   cod4x)
     echo "CoD4x game detected. Handing off to CoD4x entrypoint..."
     exec "$SCRIPT_DIR/cod4xentry.sh"
+    ;;
+  7dtd)
+    echo "7 Days to Die detected. Handing off to the native Linux entrypoint..."
+    exec "$SCRIPT_DIR/7dtdentry.sh"
     ;;
 esac

--- a/scripts/game-config.sh
+++ b/scripts/game-config.sh
@@ -36,16 +36,64 @@ hold_indefinitely() {
   exec sleep infinity
 }
 
-# Run the game binary, then sleep 30s before letting the container exit.
+# Run the game binary, forward Docker's stop signal, then sleep 30s before
+# letting the container exit after an unrequested game crash.
 # Restart policies (e.g. `restart: unless-stopped`) react to container exit
 # but docker compose has no native min-delay knob — the in-script sleep is
 # how we throttle real crashes to one restart per ~30s.
+#
+# A game entrypoint may define graceful_shutdown_game(). On SIGTERM/SIGINT it
+# is called while the child is still running, then this wrapper waits for the
+# child to finish. Families without that hook retain the historical immediate
+# stop by receiving SIGKILL. Docker kills the whole container if its configured
+# stop timeout expires, so a broken graceful hook cannot hang forever.
 # Args: command + its arguments (e.g. wine ...).
 launch_game() {
   set +e
-  "$@"
-  local rc=$?
+  "$@" &
+  local game_pid=$!
+  local rc=0
+  local stop_requested=false
+
+  _plutainer_handle_stop() {
+    stop_requested=true
+    # Docker normally sends one signal, but ignore repeats while the graceful
+    # hook is running. Its stop timeout remains the hard upper bound.
+    trap - TERM INT
+
+    if declare -F graceful_shutdown_game >/dev/null 2>&1; then
+      echo "[INFO] Stop requested; asking the game server to shut down gracefully."
+      if ! graceful_shutdown_game "$game_pid"; then
+        echo "[WARN] Graceful shutdown request failed; forwarding SIGTERM to the game process." >&2
+        kill -TERM "$game_pid" 2>/dev/null || true
+      fi
+    else
+      # Preserve the pre-existing instant-stop behaviour for the CoD engines.
+      kill -KILL "$game_pid" 2>/dev/null || true
+    fi
+  }
+
+  trap _plutainer_handle_stop TERM INT
+
+  # `wait` returns when a trapped signal interrupts it even if the child is
+  # still alive. Re-enter it after the graceful request and wait for the real
+  # process exit.
+  while true; do
+    wait "$game_pid"
+    rc=$?
+    if [[ "$stop_requested" == "true" ]] && kill -0 "$game_pid" 2>/dev/null; then
+      continue
+    fi
+    break
+  done
+
+  trap - TERM INT
   set -e
+
+  if [[ "$stop_requested" == "true" ]]; then
+    echo "[INFO] Game server stopped."
+    exit 0
+  fi
 
   echo "[INFO] Game process exited (rc=$rc)." >&2
   echo "[INFO] Sleeping 30s before container exit to throttle restart." >&2
@@ -53,7 +101,7 @@ launch_game() {
   exit "$rc"
 }
 
-# Derive the game family ("plutonium", "iw4x", "alterware") from PLUTAINER_GAME.
+# Derive the game family from PLUTAINER_GAME.
 # Returns 1 if unknown.
 derive_family() {
   case "$1" in
@@ -61,6 +109,7 @@ derive_family() {
     iw4x)                                echo "iw4x" ;;
     t7x)                                 echo "alterware" ;;
     cod4x)                               echo "cod4x" ;;
+    7dtd)                                echo "7dtd" ;;
     *)                                   return 1 ;;
   esac
 }
@@ -84,6 +133,7 @@ detect_game_type() {
     iw4x)      BASE_GAME="iw4x" ;;
     alterware) BASE_GAME="${GAME_NAME}" ;;
     cod4x)     BASE_GAME="cod4x" ;;
+    7dtd)      BASE_GAME="7dtd" ;;
   esac
 
   CONFIG_FILE="${PLUTAINER_CONFIG_FILE:-}"
@@ -101,6 +151,7 @@ resolve_default_port() {
     "t6")        DEFAULT_PORT="4976"  ;;
     "t7x")       DEFAULT_PORT="27017" ;;
     "cod4x")     DEFAULT_PORT="28960" ;;
+    "7dtd")      DEFAULT_PORT="26900" ;;
     *)
       echo "[ERROR] Could not determine default port for game '${base_game}'." >&2
       return 1
@@ -123,6 +174,7 @@ resolve_engine_config_dir() {
     iw4x)      ENGINE_CONFIG_DIR="$PLUTAINER_GAMEFILES_DIR/userraw" ;;
     alterware) ENGINE_CONFIG_DIR="$PLUTAINER_GAMEFILES_DIR/zone" ;;
     cod4x)     ENGINE_CONFIG_DIR="$PLUTAINER_GAMEFILES_DIR/main" ;;
+    7dtd)      ENGINE_CONFIG_DIR="$PLUTAINER_CONFIGS_DIR" ;;
     *)
       echo "[ERROR] Unknown game type '${GAME_TYPE}'." >&2
       return 1

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Liveness check: ask the server for its status over the Quake3 UDP protocol
-# and require it to name a loaded map.
+# Liveness check. Call of Duty servers use the Quake3 UDP status protocol;
+# 7 Days to Die uses a process plus TCP-listener check.
 #
 # Uses the unauthenticated `getstatus` query rather than RCON `status`. Both are
 # handled by the same connectionless-packet path inside the same server frame
@@ -27,6 +27,53 @@ echo "       - ${GAME_TYPE} server detected (${GAME_NAME})."
 if [[ "${HEALTHCHECK_FLAG}" == "false" ]]; then
   echo "[INFO] Health check is disabled by environment variable."
   exit 0
+fi
+
+# 7DTD is not a Quake-derived engine and does not answer getstatus/getinfo.
+# Its game port has a TCP listener, so require both the dedicated process and
+# a successful loopback connection. This catches a dead process and a server
+# that is still starting or has failed before binding its game socket.
+if [[ "$GAME_TYPE" == "7dtd" ]]; then
+  HEALTHCHECK_PORT=${CUSTOM_PORT}
+  if [[ -z "$HEALTHCHECK_PORT" ]]; then
+    config_path="$PLUTAINER_CONFIGS_DIR/${PLUTAINER_CONFIG_FILE:-serverconfig.xml}"
+    if [[ -f "$config_path" ]]; then
+      HEALTHCHECK_PORT=$(python3 - "$config_path" <<'PY'
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    text = fh.read()
+match = re.search(
+    r'<property\s+name=["\']ServerPort["\']\s+value=["\'](\d+)["\']',
+    text,
+    re.IGNORECASE,
+)
+print(match.group(1) if match else "")
+PY
+      )
+    fi
+    if [[ -z "$HEALTHCHECK_PORT" ]]; then
+      resolve_default_port || exit 1
+      HEALTHCHECK_PORT="$DEFAULT_PORT"
+    fi
+  fi
+
+  pgrep -f '[/]7DaysToDieServer.x86_64' >/dev/null || {
+    echo "[ERROR] 7 Days to Die server process is not running." >&2
+    exit 1
+  }
+
+  python3 - "$HEALTHCHECK_PORT" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+with socket.create_connection(("127.0.0.1", port), timeout=5):
+    pass
+print(f"[OK] 7 Days to Die is accepting TCP connections on port {port}.")
+PY
+  exit $?
 fi
 
 # --- Step 3: Determine the correct port to check ---


### PR DESCRIPTION
## Summary

- add native Linux 7 Days to Die dedicated-server support with `PLUTAINER_GAME=7dtd`
- install and update Steam app `294420` through SteamCMD while keeping server files, worlds, saves, configuration, admins, logs, and mods persistent
- add 7DTD-aware port handling, XML configuration, health checks, Compose examples, and documentation
- forward Docker stop signals to 7DTD's native `ServerShutdown` path and allow time for a graceful world save
- report the unsupported arm64 case clearly without breaking the existing arm64 image

## Why

Plutainer previously supported only the Call of Duty server families. This adds 7 Days to Die using the same environment-driven container workflow without requiring users to supply game files or a Steam account.

## Validation

- built the amd64 Docker image successfully
- ran `bash -n` against the entrypoint, shared configuration, healthcheck, and 7DTD scripts inside the built image
- started a live server, joined it successfully, and confirmed the healthcheck on TCP/UDP port `26900`
- verified SteamCMD update checks and persistence across container recreation
- verified a Docker-level graceful stop: 7DTD logged `ServerShutdown`, saved world state, exited with code `0`, and returned healthy after restart
- ran `git diff --check`

VPS-specific Compose settings, server XML, credentials, saves, and deployment data are not included.
